### PR TITLE
Removing a comma from postgresql config

### DIFF
--- a/postgresSQL.nomad
+++ b/postgresSQL.nomad
@@ -21,7 +21,7 @@ job "postgres" {
 
       }
       env {
-          POSTGRES_USER="root",
+          POSTGRES_USER="root"
           POSTGRES_PASSWORD="rootpassword"
       }
 


### PR DESCRIPTION
Guess it's a typo, causing:`Error getting job struct: Failed to parse using HCL 2. Use the HCL 1 parser with `nomad run -hcl1`, or address the following issues:
postgresSQL.nomad:24,31-32: Unexpected comma after argument; Argument definitions must be separated by newlines, not commas. An argument definition must end with a newline.`